### PR TITLE
Improve interoperability of column names

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ with readme: 33`
 ```
 Additionally this information is also provided per namespace:
 ```
-name space               , with lic, w/o lic,  readme
+namespace                ,  with_lic,   no_lic,   readme
 abc                      ,        3 ,        3,        3
 def                      ,        0 ,        1,        0
 ghi                      ,        1 ,        3,        0

--- a/src/main/groovy/org/derse/gitlabintrospection/GitlabLicenses.groovy
+++ b/src/main/groovy/org/derse/gitlabintrospection/GitlabLicenses.groovy
@@ -83,7 +83,7 @@ class GitlabLicenses {
         println "with readme: ${fullProjects.findAll { !it.readme_url }.size()}"
         println ""
 
-        printf('%-25s, %8s,%8s,%8s\n',['name space','with lic','w/o lic','readme'])
+        printf('%-25s, %8s,%8s,%8s\n',['namespace','with_lic','no_lic','readme'])
         fullProjects.namespace.name.unique().each { namespace ->
             def namespaceProjects = fullProjects.findAll { it.namespace.name.equals(namespace) }
 


### PR DESCRIPTION
Hello & thanks for publishing this :-)

For downstream analysis, would it be useful to have column names with only word characters in the output?
